### PR TITLE
Upgrade `@babel/traverse` to resolve CVE-2023-45133

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -152,7 +152,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.4.0, @babel/generator@npm:^7.9.5":
+"@babel/generator@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/generator@npm:7.23.0"
+  dependencies:
+    "@babel/types": ^7.23.0
+    "@jridgewell/gen-mapping": ^0.3.2
+    "@jridgewell/trace-mapping": ^0.3.17
+    jsesc: ^2.5.1
+  checksum: 8efe24adad34300f1f8ea2add420b28171a646edc70f2a1b3e1683842f23b8b7ffa7e35ef0119294e1901f45bfea5b3dc70abe1f10a1917ccdfb41bed69be5f1
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.4.0":
   version: 7.9.5
   resolution: "@babel/generator@npm:7.9.5"
   dependencies:
@@ -161,19 +173,6 @@ __metadata:
     lodash: ^4.17.13
     source-map: ^0.5.0
   checksum: 68805ad1082e5cc3574eff5fc03444b5b0ab02dce36c107bfaa1a7bed0733dcd4c28348ad35efb7b4b8597c734d3087022ba7772f8c84c9e79b029f27bc90654
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.5.5":
-  version: 7.5.5
-  resolution: "@babel/generator@npm:7.5.5"
-  dependencies:
-    "@babel/types": ^7.5.5
-    jsesc: ^2.5.1
-    lodash: ^4.17.13
-    source-map: ^0.5.0
-    trim-right: ^1.0.1
-  checksum: efe56ad62976dc948d1649fa8d43b3abf27f711d5635df98ab695ed440bbc07367fa45590673a2e996759bfb710ca70f11331eda8590f455e66057da3825dc22
   languageName: node
   linkType: hard
 
@@ -260,7 +259,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.0.0, @babel/helper-function-name@npm:^7.1.0":
+"@babel/helper-function-name@npm:^7.0.0":
   version: 7.1.0
   resolution: "@babel/helper-function-name@npm:7.1.0"
   dependencies:
@@ -271,35 +270,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.22.5":
-  version: 7.22.5
-  resolution: "@babel/helper-function-name@npm:7.22.5"
+"@babel/helper-function-name@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/helper-function-name@npm:7.23.0"
   dependencies:
-    "@babel/template": ^7.22.5
-    "@babel/types": ^7.22.5
-  checksum: 6b1f6ce1b1f4e513bf2c8385a557ea0dd7fa37971b9002ad19268ca4384bbe90c09681fe4c076013f33deabc63a53b341ed91e792de741b4b35e01c00238177a
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "@babel/helper-function-name@npm:7.7.4"
-  dependencies:
-    "@babel/helper-get-function-arity": ^7.7.4
-    "@babel/template": ^7.7.4
-    "@babel/types": ^7.7.4
-  checksum: e668e933c31f5fd3fb06c7ff2b42d03d1e9c04e5b75d0039fdab712fffcbb65bf846ba742b286124d30ad0e1dd7158d92cd58cbb97031a04c6e3145376ece824
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.9.5":
-  version: 7.9.5
-  resolution: "@babel/helper-function-name@npm:7.9.5"
-  dependencies:
-    "@babel/helper-get-function-arity": ^7.8.3
-    "@babel/template": ^7.8.3
-    "@babel/types": ^7.9.5
-  checksum: c00f3a52e86613809ca363adbc3a7a506438829ed7ab7bd4e818b7a2146df4d6b185fee6c33bb172dd6616671c2ecb9428caf7da4aaacd07581e8187643d38a3
+    "@babel/template": ^7.22.15
+    "@babel/types": ^7.23.0
+  checksum: e44542257b2d4634a1f979244eb2a4ad8e6d75eb6761b4cfceb56b562f7db150d134bc538c8e6adca3783e3bc31be949071527aa8e3aab7867d1ad2d84a26e10
   languageName: node
   linkType: hard
 
@@ -309,24 +286,6 @@ __metadata:
   dependencies:
     "@babel/types": ^7.0.0
   checksum: 52444ebf7545780ef2915d8255702e728dcf370edda83f0d0d76bc750c12aafaebcb3a3c032e9054e50e45b3c2f07e774d846a35f17f6e73075cb4cfd9a17a36
-  languageName: node
-  linkType: hard
-
-"@babel/helper-get-function-arity@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "@babel/helper-get-function-arity@npm:7.7.4"
-  dependencies:
-    "@babel/types": ^7.7.4
-  checksum: c5a31a5d3d6bd4ab205b419b9d7b6c275e3f071ef5925acf0337d2fca6677bede8b5a250c0793f1a54a8dfeff809a29d8908bc7ba7f891ca9efc11ab63c93e9e
-  languageName: node
-  linkType: hard
-
-"@babel/helper-get-function-arity@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/helper-get-function-arity@npm:7.8.3"
-  dependencies:
-    "@babel/types": ^7.8.3
-  checksum: f36d939bc565576f47c546ee636a37d0597ebdde30182db974cf47b27d4ee3a72a53233e45bdb57dac306ff5b03a2083d9d2fa8291d95d93bfe4f6213a6901e2
   languageName: node
   linkType: hard
 
@@ -496,7 +455,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.0.0, @babel/helper-split-export-declaration@npm:^7.4.4":
+"@babel/helper-split-export-declaration@npm:^7.0.0":
   version: 7.4.4
   resolution: "@babel/helper-split-export-declaration@npm:7.4.4"
   dependencies:
@@ -511,24 +470,6 @@ __metadata:
   dependencies:
     "@babel/types": ^7.22.5
   checksum: e141cace583b19d9195f9c2b8e17a3ae913b7ee9b8120246d0f9ca349ca6f03cb2c001fd5ec57488c544347c0bb584afec66c936511e447fd20a360e591ac921
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "@babel/helper-split-export-declaration@npm:7.7.4"
-  dependencies:
-    "@babel/types": ^7.7.4
-  checksum: 2930c55ba33d66a01ebc9dbb0606bd2b71bad2a9ac25f174f60674a73c20718248ef6204af1b573a5da68aa7ced62b287fb7a3d3a7723dc0ac584826f7123493
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/helper-split-export-declaration@npm:7.8.3"
-  dependencies:
-    "@babel/types": ^7.8.3
-  checksum: a8b5ce6d309002ef85f1514346f3929653c7319f40d98b7d56014a26b7c8b7517cabca12007c71bda513d0f1a0b7548afe9646ee269cbad2b7e7e43455fa0eef
   languageName: node
   linkType: hard
 
@@ -672,7 +613,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.4.3, @babel/parser@npm:^7.8.6, @babel/parser@npm:^7.9.0":
+"@babel/parser@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/parser@npm:7.23.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 453fdf8b9e2c2b7d7b02139e0ce003d1af21947bbc03eb350fb248ee335c9b85e4ab41697ddbdd97079698de825a265e45a0846bb2ed47a2c7c1df833f42a354
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.4.3, @babel/parser@npm:^7.8.6":
   version: 7.9.4
   resolution: "@babel/parser@npm:7.9.4"
   bin:
@@ -681,7 +631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.4.4, @babel/parser@npm:^7.5.5":
+"@babel/parser@npm:^7.4.4":
   version: 7.5.5
   resolution: "@babel/parser@npm:7.5.5"
   bin:
@@ -1415,7 +1365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.22.15, @babel/template@npm:^7.22.5":
+"@babel/template@npm:^7.22.15":
   version: 7.22.15
   resolution: "@babel/template@npm:7.22.15"
   dependencies:
@@ -1437,7 +1387,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.4.0, @babel/template@npm:^7.8.3":
+"@babel/template@npm:^7.4.0":
   version: 7.8.6
   resolution: "@babel/template@npm:7.8.6"
   dependencies:
@@ -1459,76 +1409,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.0.0":
-  version: 7.5.5
-  resolution: "@babel/traverse@npm:7.5.5"
-  dependencies:
-    "@babel/code-frame": ^7.5.5
-    "@babel/generator": ^7.5.5
-    "@babel/helper-function-name": ^7.1.0
-    "@babel/helper-split-export-declaration": ^7.4.4
-    "@babel/parser": ^7.5.5
-    "@babel/types": ^7.5.5
-    debug: ^4.1.0
-    globals: ^11.1.0
-    lodash: ^4.17.13
-  checksum: 099dc9740f74646fd67e10747e70ea0d4674ed8acff6b605ac592ae2f20af086f0b5b3efc0e5a7afe23093e2db9dd5d5fa59371c9aab9cdcf95b494415e221f3
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.22.15, @babel/traverse@npm:^7.22.20, @babel/traverse@npm:^7.7.0":
-  version: 7.22.20
-  resolution: "@babel/traverse@npm:7.22.20"
+"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.22.15, @babel/traverse@npm:^7.22.20, @babel/traverse@npm:^7.4.3, @babel/traverse@npm:^7.7.0, @babel/traverse@npm:^7.7.4":
+  version: 7.23.2
+  resolution: "@babel/traverse@npm:7.23.2"
   dependencies:
     "@babel/code-frame": ^7.22.13
-    "@babel/generator": ^7.22.15
+    "@babel/generator": ^7.23.0
     "@babel/helper-environment-visitor": ^7.22.20
-    "@babel/helper-function-name": ^7.22.5
+    "@babel/helper-function-name": ^7.23.0
     "@babel/helper-hoist-variables": ^7.22.5
     "@babel/helper-split-export-declaration": ^7.22.6
-    "@babel/parser": ^7.22.16
-    "@babel/types": ^7.22.19
+    "@babel/parser": ^7.23.0
+    "@babel/types": ^7.23.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 97da9afa7f8f505ce52c36ac2531129bc4a0e250880aaf9b467dc044f30a5bce2b756c1af4d961958bc225659546e811a7d536ab3d920fd60921087989b841b9
+  checksum: 26a1eea0dde41ab99dde8b9773a013a0dc50324e5110a049f5d634e721ff08afffd54940b3974a20308d7952085ac769689369e9127dea655f868c0f6e1ab35d
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.4.3":
-  version: 7.9.5
-  resolution: "@babel/traverse@npm:7.9.5"
-  dependencies:
-    "@babel/code-frame": ^7.8.3
-    "@babel/generator": ^7.9.5
-    "@babel/helper-function-name": ^7.9.5
-    "@babel/helper-split-export-declaration": ^7.8.3
-    "@babel/parser": ^7.9.0
-    "@babel/types": ^7.9.5
-    debug: ^4.1.0
-    globals: ^11.1.0
-    lodash: ^4.17.13
-  checksum: e5ac9c3a6a6076d8fd34ae673de56f7dbf39263c4e32f893011563c8ef5cac652d51d41efd2bb923153950c9c2c8483a90033a458fb0f236783439ff72166a87
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.7.4":
-  version: 7.7.4
-  resolution: "@babel/traverse@npm:7.7.4"
-  dependencies:
-    "@babel/code-frame": ^7.5.5
-    "@babel/generator": ^7.7.4
-    "@babel/helper-function-name": ^7.7.4
-    "@babel/helper-split-export-declaration": ^7.7.4
-    "@babel/parser": ^7.7.4
-    "@babel/types": ^7.7.4
-    debug: ^4.1.0
-    globals: ^11.1.0
-    lodash: ^4.17.13
-  checksum: 0966902dae027abae000b41ac9e3ec7b7fcd4834d0930c348d6e44a67e8235566ead4b03f498690120f6af8d2fb8f6c8ababb3b03effa6548518f059a6eb688e
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.4.4, @babel/types@npm:^7.5.5":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.4.4":
   version: 7.5.5
   resolution: "@babel/types@npm:7.5.5"
   dependencies:
@@ -1558,6 +1457,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.22.19
     to-fast-properties: ^2.0.0
   checksum: 2d69740e69b55ba36ece0c17d5afb7b7213b34297157df39ef9ba24965aff677c56f014413052ecc5b2fbbf26910c63e5bb24a969df84d7a17153750cf75915e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/types@npm:7.23.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.20
+    to-fast-properties: ^2.0.0
+  checksum: 215fe04bd7feef79eeb4d33374b39909ce9cad1611c4135a4f7fdf41fe3280594105af6d7094354751514625ea92d0875aba355f53e86a92600f290e77b0e604
   languageName: node
   linkType: hard
 
@@ -9951,13 +9861,6 @@ __metadata:
   version: 1.1.0
   resolution: "treeify@npm:1.1.0"
   checksum: aa00dded220c1dd052573bd6fc2c52862f09870851a284f0d3650d72bf913ba9b4f6b824f4f1ab81899bae29375f4266b07fe47cbf82343a1efa13cc09ce87af
-  languageName: node
-  linkType: hard
-
-"trim-right@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "trim-right@npm:1.0.1"
-  checksum: 9120af534e006a7424a4f9358710e6e707887b6ccf7ea69e50d6ac6464db1fe22268400def01752f09769025d480395159778153fb98d4a2f6f40d4cf5d4f3b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Resolve CVE-2023-45133
# Testing
## How can the other reviewers check that your change works?
build should pass
  | Affected versions | Patched versions |
  |-|-|
  | < 7.23.2 | 7.23.2 |
  | >= 8.0.0-alpha.0, < 8.0.0-alpha.4 | 8.0.0-alpha.4 |

### Before
```zsh
   └─ @babel/traverse@npm:7.9.5 (via npm:^7.4.3)
│  └─ @babel/traverse@npm:7.22.20 (via npm:^7.22.15)
│  └─ @babel/traverse@npm:7.22.20 (via npm:^7.22.20)
│  └─ @babel/traverse@npm:7.22.20 (via npm:^7.7.0)
│  └─ @babel/traverse@npm:7.5.5 (via npm:^7.0.0)
│  └─ @babel/traverse@npm:7.7.4 (via npm:^7.7.4)
```

### After
```zsh
   └─ @babel/traverse@npm:7.23.2 (via npm:^7.4.3)
│  └─ @babel/traverse@npm:7.23.2 (via npm:^7.0.0)
│  └─ @babel/traverse@npm:7.23.2 (via npm:^7.22.15)
│  └─ @babel/traverse@npm:7.23.2 (via npm:^7.22.20)
│  └─ @babel/traverse@npm:7.23.2 (via npm:^7.7.0)
│  └─ @babel/traverse@npm:7.23.2 (via npm:^7.7.4)
```
