### PR TITLE
Upgrade `tar` to partially resolve CVE-2024-28863

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7371,10 +7371,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^4.0.0":
-  version: 4.2.8
-  resolution: "minipass@npm:4.2.8"
-  checksum: 7f4914d5295a9a30807cae5227a37a926e6d910c03f315930fde52332cf0575dfbc20295318f91f0baf0e6bb11a6f668e30cde8027dea7a11b9d159867a3c830
+"minipass@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass@npm:5.0.0"
+  checksum: 425dab288738853fded43da3314a0b5c035844d6f3097a8e3b5b29b328da8f3c1af6fc70618b32c29ff906284cf6406b6841376f21caaadd0793c1d5a6a620ea
   languageName: node
   linkType: hard
 
@@ -9750,16 +9750,16 @@ __metadata:
   linkType: hard
 
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
-  version: 6.1.13
-  resolution: "tar@npm:6.1.13"
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
-    minipass: ^4.0.0
+    minipass: ^5.0.0
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: 8a278bed123aa9f53549b256a36b719e317c8b96fe86a63406f3c62887f78267cea9b22dc6f7007009738509800d4a4dccc444abd71d762287c90f35b002eb1c
+  checksum: f1322768c9741a25356c11373bce918483f40fa9a25c69c59410c8a1247632487edef5fe76c5f12ac51a6356d2f1829e96d2bc34098668a2fc34d76050ac2b6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Bump `tar` package to partially resolve CVE-2024-28863
  | Affected versions | Patched versions |
  |-|-|
  | < 6.2.1 | 6.2.1 |

### Before
```zsh
yarn why tar
   └─ tar@npm:4.4.19 (via npm:^4.4.13)
│  └─ tar@npm:6.1.13 (via npm:^6.1.11)
│  └─ tar@npm:6.1.13 (via npm:^6.1.2)



```

### After
```zsh
yarn why tar
   └─ tar@npm:4.4.19 (via npm:^4.4.13)
│  └─ tar@npm:6.2.1 (via npm:^6.1.11)
│  └─ tar@npm:6.2.1 (via npm:^6.1.2)


=
```

# Testing
## How can the other reviewers check that your change works?
build should pass
