### PR TITLE
use public shared workflows for public repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,31 @@ updates:
     allow:
       - dependency-name: "@cumulusds/*"
         dependency-type: "all"
-      - dependency-name: "serverless-*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - npm-npmjs
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "America/New_York"
+    commit-message: # Prefix all commit messages with "npm security: "
+      prefix: "npm security"
+    labels:
+      - "dependencies"
+    assignees:
+      - "jeffsays"
+    reviewers:
+      - "jeffsays"
+    allow: # Provide security updates, but not version updates, for open-source packages
+      - dependency-name: "*"
         dependency-type: "all"
-      - dependency-name: "serverless"
-        dependency-type: "all"
+    ignore: # Issue security updates, but not regular updates, for public packages
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+          - version-update:semver-patch
+    target-branch: master # specifying target-branch in one configuration and not the other is a loophole that allows
+    # us to have two configurations for "npm".  see open feature request:
+    # https://github.com/dependabot/dependabot-core/issues/1778#issuecomment-1988140219

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,12 +11,21 @@ labels:
 - name: automerge
   description: automergable
   color: "fbca04"
+- name: blocker
+  description: An issue that blocks prod release
+  color: "b60205"
+- name: breaking
+  description: Breaking Changes
+  color: bfd4f2
 - name: bug
   description: Something isn't working
   color: "d73a4a"
 - name: config
   description: configuration change
   color: "0e8a16"
+- name: dependabot
+  description: Pull requests opened by dependabot
+  color: 006b75
 - name: dependencies
   description: Pull requests that update a dependency file
   color: "0366d6"
@@ -64,9 +73,13 @@ repos:
   labels:
   - actions
   - autoapprove
+  - automation
   - automerge
+  - blocker
+  - breaking
   - bug
   - config
+  - dependabot
   - dependencies
   - deployment
   - dev

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   assignAuthor:
     name: Assign author
-    uses: CumulusDS/workflows/.github/workflows/assign.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/assign.yml@master
     secrets: inherit

--- a/.github/workflows/autolabeler.yml
+++ b/.github/workflows/autolabeler.yml
@@ -3,5 +3,5 @@ on: [pull_request_target]
 jobs:
   label:
     name: Auto Labeler
-    uses: CumulusDS/workflows/.github/workflows/autolabeler.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/autolabeler.yml@master
     secrets: inherit

--- a/.github/workflows/delete-prerelease.yml
+++ b/.github/workflows/delete-prerelease.yml
@@ -4,5 +4,5 @@ jobs:
   remove-tag:
     name: Remove distribution tag
     if: github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dependabot/')
-    uses: Cumulusds/workflows/.github/workflows/package-prerelease-delete.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/package-prerelease-delete.yml@master
     secrets: inherit

--- a/.github/workflows/dependabot-automerger.yml
+++ b/.github/workflows/dependabot-automerger.yml
@@ -9,5 +9,5 @@ on:
 jobs:
   dependabot-automerge:
     name: Dependabot AutoMerger
-    uses: CumulusDS/workflows/.github/workflows/dependabot-automerger.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/dependabot-automerger.yml@master
     secrets: inherit

--- a/.github/workflows/labels_import.yml
+++ b/.github/workflows/labels_import.yml
@@ -8,5 +8,5 @@ on:
 jobs:
   import:
     name: Import Labels
-    uses: CumulusDS/workflows/.github/workflows/labels-import.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/labels-import.yml@master
     secrets: inherit

--- a/.github/workflows/labels_sync.yml
+++ b/.github/workflows/labels_sync.yml
@@ -8,5 +8,5 @@ on:
 jobs:
   sync:
     name: Sync Labels
-    uses: CumulusDS/workflows/.github/workflows/labels-sync.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/labels-sync.yml@master
     secrets: inherit

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -8,5 +8,5 @@ permissions:
 jobs:
   package-checker:
     name: Package Checker
-    uses: CumulusDS/workflows/.github/workflows/packages.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/packages.yml@master
     secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,25 @@
+name: Prerelease
+on:
+  push:
+    tags-ignore:
+      - "**"
+    branches-ignore:
+      - "dependabot/**"
+    paths:
+      - .github/workflows/prerelease.yml
+      - .babelrc.js
+      - .eslintrc.js
+      - .flowconfig
+      - .yarnrc.yml
+      - package.json
+      - prettier.config.js
+      - yarn.lock
+      - src/**/*
+      - test/**/*
+      - README.md
+      - .yarn/versions/*
+jobs:
+  prerelease:
+    name: Publish Prerelease
+    uses: CumulusDS/workflows/.github/workflows/package-prerelease.yml@master
+    secrets: inherit

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,5 +21,5 @@ on:
 jobs:
   prerelease:
     name: Publish Prerelease
-    uses: CumulusDS/workflows/.github/workflows/package-prerelease.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/package-prerelease.yml@master
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ jobs:
   unit:
     name: Unit
     if: github.event_name == 'release'
-    uses: CumulusDS/workflows/.github/workflows/package-publish.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/package-publish.yml@master
     secrets: inherit
     with:
       access: public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,5 @@ on:
 jobs:
   release:
     name: Create Release
-    uses: CumulusDS/workflows/.github/workflows/create-release.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/create-release.yml@master
     secrets: inherit

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -15,7 +15,7 @@ jobs:
     if: | # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
       (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
       (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
-    uses: CumulusDS/workflows/.github/workflows/package-unit.yml@master
+    uses: CumulusDS/workflows-public/.github/workflows/package-unit.yml@master
     secrets: inherit
     with: # account for dependabot; otherwise we want blank ref for downstream actions
       ref: ${{ github.event.pull_request.head.sha || '' }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,71 +1,21 @@
 name: Unit
 on:
   push:
-    branches:
-      - '**/*'
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
     types: [opened, synchronize, reopened]
+    branches-ignore:
+      - 'dependabot/**'
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 jobs:
   unit:
     name: Unit
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        node:
-          - 18
-          - 20
-          - 21
-    steps:
-      # Setup
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v3
-      - name: Get yarn v3 cache directory
-        id: get-yarn3-cache
-        run: |
-          echo "::group::Get yarn cache directory"
-          echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-          echo "::endgroup::"
-        shell: bash
-      - name: Restore yarn cache directory
-        id: restore-yarn-cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.get-yarn3-cache.outputs.dir || steps.get-yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: yarn v3 install
-        id: yarn3-install
-        run: |
-          echo "::group::Yarn Install"
-          yarn install --immutable
-          echo "::endgroup::"
-        shell: bash
-
-      # Test
-      - name: Check Licenses
-        id: check-licenses
-        run: |
-          echo "::group::Check Licenses"
-          yarn build:license-checker
-          echo "::endgroup::"
-        shell: bash
-      - name: Yarn test
-        id: yarn-test
-        run: |
-          echo "::group::yarn test"
-          yarn test
-          echo "::endgroup::"
-        shell: bash
-
-      # Upload
-      - name: Upload artifacts
-        id: upload-artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: artifacts-node-${{ matrix.node }}
-          path: var
+    if: | # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
+      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
+      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
+    uses: CumulusDS/workflows/.github/workflows/package-unit.yml@master
+    secrets: inherit
+    with: # account for dependabot; otherwise we want blank ref for downstream actions
+      ref: ${{ github.event.pull_request.head.sha || '' }}


### PR DESCRIPTION
# Summary
## What does this PR do?
- uses shared workflows publicly accessible from new `workflows-public` repository
- update dependabot configuration
- update labels

# Details
## Why did you make this change? What does it affect?
hopefully unblock @massfords 

# Testing
## How can the other reviewers check that your change works?
everything should be green