### PR TITLE
remove issue auto assign on issues created

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,7 +1,5 @@
 name: Assigner
 on:
-  issues:
-    types: [opened, reopened]
   pull_request_target:
     types: [opened, reopened]
 jobs:


### PR DESCRIPTION
# Summary
## What does this PR do?
stops auto-assignment of issues upon creation

# Details
## Why did you make this change? What does it affect?
noted during standup that we have some incorrect issue assignments due to the overzealous auto-assign workflow

# Testing
## How can the other reviewers check that your change works?
open an issue and boom, no more auto-assignment