### PR TITLE
Upgrade `cross-spawn` version(s) to resolve CVE-2024-21538

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,7 +3548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.2":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -3556,6 +3556,17 @@ __metadata:
     shebang-command: ^2.0.0
     which: ^2.0.1
   checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.3":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: ^3.1.0
+    shebang-command: ^2.0.0
+    which: ^2.0.1
+  checksum: 8d306efacaf6f3f60e0224c287664093fa9185680b2d195852ba9a863f85d02dcc737094c6e512175f8ee0161f9b87c73c6826034c2422e39de7d6569cf4503b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Closes #34
- Bump `cross-spawn` package to resolve CVE-2024-21538
  | Affected versions | Patched versions |
  |-|-|
  | < fill in | 6.0.5 7.0.5 |

### Before

We had 2 ^7.0.2 ^7.0.3 version(s) being requested for install
1 version(s) were installed: 7.0.3

```zsh
yarn why cross-spawn
   └─ cross-spawn@npm:7.0.3 (via npm:^7.0.3)
│  └─ cross-spawn@npm:7.0.3 (via npm:^7.0.2)
```

### After
```zsh
yarn why cross-spawn
   └─ cross-spawn@npm:7.0.6 (via npm:^7.0.3)
│  └─ cross-spawn@npm:7.0.3 (via npm:^7.0.2)
```

# Testing
## How can the other reviewers check that your change works?
- build should pass
 