### PR TITLE
bump `Cross-spawn` version(s) to resolve vulnerability CVE-2024-21538 resolved all versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,18 +3548,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "cross-spawn@npm:7.0.3"
-  dependencies:
-    path-key: ^3.1.0
-    shebang-command: ^2.0.0
-    which: ^2.0.1
-  checksum: 671cc7c7288c3a8406f3c69a3ae2fc85555c04169e9d611def9a675635472614f1c0ed0ef80955d5b6d4e724f6ced67f0ad1bb006c2ea643488fcfef994d7f52
-  languageName: node
-  linkType: hard
-
-"cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -7826,11 +7815,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.6.2#~builtin<compat/typescript>":
   version: 5.6.2
-  resolution: "typescript@patch:typescript@npm%3A5.6.2#~builtin<compat/typescript>::version=5.6.2&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#~builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: c084ee1ab865f108c787e6233a5f63c126c482c0c8e87ec998ac5288a2ad54b603e1ea8b8b272355823b833eb31b9fabb99e8c6152283e1cb47e3a76bd6faf6c
+  checksum: be6138b734b2d5f6aa9844b760d6a9e853d395e55ec4570ff1026cca195e5968849e38907c18f9c5b35f6a38e4e18ec29937f1c2ae03c6405e9874ad45d810b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In #34 version ^7.0.3 has not been resolved.

## What does this PR do?
- Closes #34
- Bump `cross-spawn` package to resolve CVE-2024-21538
  | Affected versions | Patched versions |
  |-|-|
  | < fill in | 6.0.5 7.0.5 |

### After

```
yarn why cross-spawn                                                                                          
├─ eslint@npm:8.57.1
│  └─ cross-spawn@npm:7.0.6 (via npm:^7.0.2)
│
└─ execa@npm:5.1.1
   └─ cross-spawn@npm:7.0.6 (via npm:^7.0.3)

```